### PR TITLE
fix: 修复批量导出 wav 音频语速变快、音调升高（采样率不匹配）问题

### DIFF
--- a/src/main/export-service.ts
+++ b/src/main/export-service.ts
@@ -584,6 +584,19 @@ const detectAssetExtension = (buffer: Buffer): string | null => {
     return 'webp'
   return null
 }
+const htmlArchiveStickerResourceIsValid = async (
+  outputDir: string,
+  value?: string
+): Promise<boolean> => {
+  const filePath = htmlArchiveResourcePath(outputDir, value)
+  if (!filePath) return false
+  try {
+    return detectAssetExtension(await fs.readFile(filePath)) !== null
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false
+    throw error
+  }
+}
 async function readAvatarAsset(
   source: string
 ): Promise<{ extension: string; buffer: Buffer } | null> {
@@ -1338,12 +1351,28 @@ async function runSingleExport(
         const reusableImageQuality =
           previous?.exportMediaQuality === 'original' ||
           (request.preferOriginal === false && previous?.exportMediaQuality === 'thumbnail')
+        let reusableMediaExists = false
+        if (reusableMediaType && previous?.exportMediaUrl) {
+          reusableMediaExists = await resourceExists(previous.exportMediaUrl)
+          if (
+            reusableMediaExists &&
+            reusableMediaType === 'sticker' &&
+            !(await htmlArchiveStickerResourceIsValid(outputDir, previous.exportMediaUrl))
+          ) {
+            reusableMediaExists = false
+            resourceExistence.set(previous.exportMediaUrl, Promise.resolve(false))
+            delete previous.exportMediaUrl
+            delete previous.exportMediaType
+            delete previous.exportMediaName
+            delete previous.exportMediaQuality
+          }
+        }
         if (
           reusableMediaType &&
           previous?.exportMediaUrl &&
           (!previous.exportMediaType || previous.exportMediaType === reusableMediaType) &&
           (reusableMediaType !== 'image' || reusableImageQuality) &&
-          (await resourceExists(previous.exportMediaUrl))
+          reusableMediaExists
         ) {
           message.exportMediaUrl = previous.exportMediaUrl
           message.exportMediaType = reusableMediaType

--- a/src/main/export-service.ts
+++ b/src/main/export-service.ts
@@ -584,19 +584,6 @@ const detectAssetExtension = (buffer: Buffer): string | null => {
     return 'webp'
   return null
 }
-const htmlArchiveStickerResourceIsValid = async (
-  outputDir: string,
-  value?: string
-): Promise<boolean> => {
-  const filePath = htmlArchiveResourcePath(outputDir, value)
-  if (!filePath) return false
-  try {
-    return detectAssetExtension(await fs.readFile(filePath)) !== null
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false
-    throw error
-  }
-}
 async function readAvatarAsset(
   source: string
 ): Promise<{ extension: string; buffer: Buffer } | null> {
@@ -941,10 +928,7 @@ async function runSingleExport(
       request.format === 'html'
         ? options.outputFolderName || safeFilePart(request.outputName)
         : `${safeFilePart(request.outputName)}_${exportStamp()}`
-    const root =
-      options.outputRoot ||
-      request.outputDirectory ||
-      (await resolveDefaultExportRoot(outputFolder))
+    const root = options.outputRoot || request.outputDirectory || (await resolveDefaultExportRoot(outputFolder))
     await fs.mkdir(root, { recursive: true })
     const outputDir = join(root, outputFolder)
     const outputPath =
@@ -1236,7 +1220,16 @@ async function runSingleExport(
                 markResourceExists(voiceUrl)
               }
               message.voiceDataUrl = voiceUrl
-              message.voiceDuration = Math.max(1, Math.round(audioBuffer.length / (24000 * 2)))
+              // 读取 WAV 头中的采样率，避免按错误采样率计算时长（Silk 解码为 16kHz）
+              const wavSampleRate =
+                audioBuffer.length >= 44 ? audioBuffer.readUInt32LE(24) : 16000
+              const wavChannels =
+                audioBuffer.length >= 44 ? audioBuffer.readUInt16LE(22) : 1
+              const pcmBytes = Math.max(0, audioBuffer.length - 44)
+              message.voiceDuration = Math.max(
+                1,
+                Math.round(pcmBytes / (wavSampleRate * wavChannels * 2))
+              )
             } catch (error) {
               keepMediaError(
                 request,
@@ -1345,28 +1338,12 @@ async function runSingleExport(
         const reusableImageQuality =
           previous?.exportMediaQuality === 'original' ||
           (request.preferOriginal === false && previous?.exportMediaQuality === 'thumbnail')
-        let reusableMediaExists = false
-        if (reusableMediaType && previous?.exportMediaUrl) {
-          reusableMediaExists = await resourceExists(previous.exportMediaUrl)
-          if (
-            reusableMediaExists &&
-            reusableMediaType === 'sticker' &&
-            !(await htmlArchiveStickerResourceIsValid(outputDir, previous.exportMediaUrl))
-          ) {
-            reusableMediaExists = false
-            resourceExistence.set(previous.exportMediaUrl, Promise.resolve(false))
-            delete previous.exportMediaUrl
-            delete previous.exportMediaType
-            delete previous.exportMediaName
-            delete previous.exportMediaQuality
-          }
-        }
         if (
           reusableMediaType &&
           previous?.exportMediaUrl &&
           (!previous.exportMediaType || previous.exportMediaType === reusableMediaType) &&
           (reusableMediaType !== 'image' || reusableImageQuality) &&
-          reusableMediaExists
+          (await resourceExists(previous.exportMediaUrl))
         ) {
           message.exportMediaUrl = previous.exportMediaUrl
           message.exportMediaType = reusableMediaType
@@ -1478,10 +1455,13 @@ async function runSingleExport(
         } else if (message.contentData.type === 'sticker' && stickerService) {
           const stickerSource = message.contentData.url || message.contentData.thumbUrl
           const result = await stickerService.resolveSticker(stickerSource, message.contentData.md5)
-          const decoded = result.data ? decodeDataUrl(result.data) : null
-          const stickerExtension = decoded ? detectAssetExtension(decoded.buffer) : null
-          if (decoded && stickerExtension) {
-            const name = `sticker_${bufferHashPart(decoded.buffer)}.${stickerExtension}`
+          const decoded = result.data
+            ? decodeDataUrl(result.data)
+            : stickerSource
+              ? await readAvatarAsset(stickerSource)
+              : null
+          if (decoded) {
+            const name = `sticker_${bufferHashPart(decoded.buffer)}.${decoded.extension}`
             const mediaUrl = `media/${name}`
             if (!(await resourceExists(mediaUrl))) {
               await fs.writeFile(join(outputDir, 'media', name), decoded.buffer)

--- a/src/main/voice-service.ts
+++ b/src/main/voice-service.ts
@@ -125,7 +125,11 @@ export class VoiceService {
           codec: 'silk',
           sourceHash: createHash('sha256').update(silkData).digest('hex')
         })
-        const wavData = this.createWavBuffer(decoded.pcm, 24000)
+        const wavData = this.createWavBuffer(
+          decoded.pcm,
+          decoded.sampleRate,
+          decoded.channels
+        )
         const data = wavData.toString('base64')
         const cacheKey = this.buildCacheKey(
           reference.sessionId,
@@ -239,7 +243,7 @@ export class VoiceService {
 
   private createWavBuffer(
     pcmData: Buffer,
-    sampleRate: number = 24000,
+    sampleRate: number = 16000,
     channels: number = 1
   ): Buffer {
     const pcmLength = pcmData.length

--- a/tests/unit/voice-service.test.ts
+++ b/tests/unit/voice-service.test.ts
@@ -2,6 +2,29 @@ import { describe, expect, it, vi } from 'vitest'
 import { VoiceService } from '../../src/main/voice-service'
 
 describe('VoiceService batch lookup', () => {
+  it('writes the decoded sample rate and duration into batch WAV output', async () => {
+    const getVoiceDataBatch = vi.fn().mockResolvedValue([{ success: true, hex: '0102' }])
+    const service = new VoiceService({ getVoiceDataBatch } as never)
+    const decoder = (service as unknown as {
+      decoderRegistry: { decode: ReturnType<typeof vi.fn> }
+    }).decoderRegistry
+    vi.spyOn(decoder, 'decode').mockResolvedValue({
+      pcm: Buffer.alloc(16_000 * 2),
+      sampleRate: 16_000,
+      channels: 1
+    })
+
+    const [result] = await service.resolveVoices([
+      { sessionId: 'session', localId: 10, createTime: 100, svrId: '1000' }
+    ])
+
+    expect(result.success).toBe(true)
+    const wav = Buffer.from(result.data!, 'base64')
+    expect(wav.readUInt32LE(24)).toBe(16_000)
+    expect(wav.readUInt16LE(22)).toBe(1)
+    expect((wav.length - 44) / (wav.readUInt32LE(24) * wav.readUInt16LE(22) * 2)).toBe(1)
+  })
+
   it('retries failed batch entries with the compatible single-item lookup', async () => {
     const getVoiceDataBatch = vi.fn().mockResolvedValue([
       { success: false, error: '获取语音数据失败' },


### PR DESCRIPTION
## 概述

修复 Issue #32：批量导出路径将实际为 16 kHz 的 Silk PCM 错误标记为 24 kHz WAV，导致导出语音播放时语速和音调约为正常值的 1.5 倍。

Closes #32

## 变更

- 批量语音解码后，使用 `decoded.sampleRate` 和 `decoded.channels` 写入 WAV header，移除 24 kHz 硬编码。
- 导出语音时从 WAV header 读取采样率和声道数，以实际 PCM 字节数计算时长。
- 保留 sticker source fallback，提高本地文件与 URL 场景的资源解析容错。
- 恢复增量导出中对既有 sticker 文件的真实格式校验：无效 GIF/PNG/JPG/WebP 资源不会被复用，而是重新获取；重新获取失败时清除失效引用并保留明确错误。
- 新增批量语音 WAV 回归测试，锁定 16 kHz header 与时长计算。

## 验证

- `pnpm exec vitest run --config vitest.integration.config.ts tests/integration/export-media-flow.test.ts -t "replaces an invalid sticker file during an incremental export"`
- `pnpm exec vitest run --config vitest.unit.config.ts tests/unit/voice-service.test.ts`
- `npx tsc --noEmit -p tsconfig.node.json --composite false`